### PR TITLE
feat(tests): multiple tests in one compile(or linked) unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ set(SEA_PP "${SEAHORN_ROOT}/bin/seapp" CACHE STRING  "Path to seapp binary")
 set(LLVMIR_OPT ${SEA_OPT})
 set(SEAMOCK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src" CACHE PATH "Path to SEAMOCK src directory")
 
-#set(TRUSTY_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/trusty)
-#set(TRUSTY_MOD_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/trusty_mod)
 set(TRUSTY_TARGET "arm32" CACHE STRING "Trusty target for verification")
 #set(EXTERNAL_ROOT ${TRUSTY_ROOT}/external)
 #option(HANDLE_TYPE_IS_PTR "Build SHADOW MEM versions of jobs" OFF)
@@ -54,6 +52,10 @@ endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/examples/verify.py.in verify @ONLY)
 set(VERIFY_CMD ${CMAKE_CURRENT_BINARY_DIR}/verify)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/examples/extract_tests.cmake.in extract_tests.cmake @ONLY)
+set(EXTRACT_TEST_CMD ${CMAKE_CURRENT_BINARY_DIR}/extract_tests.cmake)
+
 
 #include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include)
 

--- a/examples/extract_tests.cmake.in
+++ b/examples/extract_tests.cmake.in
@@ -1,0 +1,34 @@
+# This CMake file is run as a script from sea_discover_tests
+# to discover tests in a bitcode file and write a new CTestTestfile
+
+# Inspired by https://github.com/Kitware/CMake/blob/master/Modules/GoogleTest.cmake
+
+set(LLVM_NM "llvm-nm-14" CACHE PATH "Path to llvm-nm")
+set(CPP_FILT "c++filt" CACHE PATH "Path to c++filt")
+set(AWK "awk" CACHE PATH "Path to awk")
+
+function(sea_discover_tests_impl TARGET BC VERIFY_CMD)
+  #sea_get_file_name(BC ${TARGET}.ir)
+  #cmake_path(APPEND_STRING TARGET ".ir" BC)
+  cmake_path(SET bcpath "${BC}")
+  cmake_path(GET bcpath PARENT_PATH bc_dir_path)
+  cmake_path(APPEND bc_dir_path "CTestTestfile.cmake" OUTPUT_VARIABLE ctest_file)
+
+  set(NM_ARGS "--defined-only")
+  # assume that functions starting with test_ are tests
+  set(AWK_ARGS "{if (($2 == \"T\") && ($3 ~ /^test_.*$/)) {print $3}}")
+  execute_process(COMMAND ${LLVM_NM} ${NM_ARGS} ${BC}
+    COMMAND ${AWK} ${AWK_ARGS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    OUTPUT_VARIABLE TEST_NAMES
+    )
+  string(REPLACE "\n" ";" TEST_NAMES_LIST ${TEST_NAMES})  # make a cmake list
+  file(REMOVE ${ctest_file})  # delete the existing CTestFile
+  foreach(TEST_NAME ${TEST_NAMES_LIST})
+      file(APPEND ${ctest_file} "add_test(${TARGET}_${TEST_NAME}_unsat_test
+            \"${VERIFY_CMD}\" \"--expect=unsat\" \"--entry-point=${TEST_NAME}\" \"${BC}\" )\n")
+      message(STATUS "Added test: ${TARGET}_${TEST_NAME}_unsat_test")
+  endforeach()
+endfunction()
+
+sea_discover_tests_impl(${TARGET} ${TEST_TARGET} ${VERIFY_CMD})

--- a/examples/seahorn/CMakeLists.txt
+++ b/examples/seahorn/CMakeLists.txt
@@ -234,7 +234,6 @@ function(sea_attach_bc_link name)
 endfunction()
 
 function(sea_attach_bc_cc_link name)
-  sea_link_libraries(${name} sea_libc_trusty.ir)
   sea_attach_bc_cc(${name})
 endfunction()
 
@@ -257,6 +256,38 @@ function(sea_add_will_fail_unsat_test TARGET)
   set_property(TEST "${TARGET}_unsat_test" PROPERTY WILL_FAIL TRUE)
 endfunction()
 
+function(sea_discover_tests TARGET)
+  sea_get_file_name(BC ${TARGET}.ir)
+  cmake_path(SET bcpath "${BC}")
+  cmake_path(GET bcpath PARENT_PATH bc_dir_path)
+  cmake_path(APPEND bc_dir_path "CTestTestfile.cmake" OUTPUT_VARIABLE ctest_file)
+  string(CONCAT target_ir ${TARGET} ".ir")
+  add_custom_command(
+    OUTPUT ${ctest_file}
+    COMMAND ${CMAKE_COMMAND}
+    ARGS
+    -D "TARGET=${TARGET}"  # name of target
+    -D "TEST_TARGET=${BC}"  # full path of linked bitcode IR file
+    -D "VERIFY_CMD=${VERIFY_CMD}"  # verify cmd to use
+    -P ${EXTRACT_TEST_CMD}  # extract tests script
+    DEPENDS ${BC}
+    COMMENT "Writing discovered tests to ${ctest_file}"
+    VERBATIM
+    )
+
+  # Add discovered tests to directory TEST_INCLUDE_FILES
+  set_property(DIRECTORY
+    APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_file}"
+  )
+  # Test discovery should run only after the linking of the final IR. For this,
+  # we need to create a custom target (discovery) that depends on the custom cmd
+  # (discovery) output and then declare that the custom target (discovery)
+  # depends on the custom cmd (linking).
+  add_custom_target("${TARGET}_disc_tests" ALL  # ALL adds it to default target list in Ninja
+    DEPENDS ${ctest_file})
+  add_dependencies("${TARGET}_disc_tests" ${target_ir})
+endfunction()
+
 # Set upper bound on data structures
 set(MSG_BUF_MAX_SIZE 4096)
 
@@ -270,3 +301,4 @@ configure_file(sea_cex_base.yaml sea.cex.yaml @ONLY)
 configure_file(sea_vac.yaml sea.vac.yaml @ONLY)
 
 add_subdirectory(ipc)
+add_subdirectory(discover_tests)

--- a/examples/seahorn/discover_tests/CMakeLists.txt
+++ b/examples/seahorn/discover_tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(example_discover_unit
+  example_discover_tests.c)
+sea_attach_bc_link(example_discover_unit)
+sea_discover_tests(example_discover_unit)

--- a/examples/seahorn/discover_tests/README.txt
+++ b/examples/seahorn/discover_tests/README.txt
@@ -1,0 +1,2 @@
+This directory contains tests to show how sea_discover_tests works.
+The source file should NOT contain a main function.

--- a/examples/seahorn/discover_tests/example_discover_tests.c
+++ b/examples/seahorn/discover_tests/example_discover_tests.c
@@ -1,0 +1,24 @@
+#include <seahorn/seahorn.h>
+#include <stddef.h>
+
+#define TEST(name)                                                             \
+  void test_##name(void);                                                      \
+  void test_##name()
+
+extern size_t nd_size_t(void);
+
+TEST(testSum1) {
+  size_t a = nd_size_t();
+  size_t b = nd_size_t();
+  assume(a < 10);
+  assume(b < 10);
+  sassert(a + b < 20);
+}
+
+TEST(testSum2) {
+  size_t a = nd_size_t();
+  size_t b = nd_size_t();
+  assume(a < 20);
+  assume(b < 20);
+  sassert(a + b < 40);
+}


### PR DESCRIPTION
This is proof of concept.
Add sea_discover_tests custom rule to CMake config to discover all tests starting with test_ and add to build/test config.

Now when ctest -R is run, the discovered tests will be picked and run using entry-point feature in seahorn.